### PR TITLE
Add peak type to MSPeak

### DIFF
--- a/corems/mass_spectrum/factory/MassSpectrumClasses.py
+++ b/corems/mass_spectrum/factory/MassSpectrumClasses.py
@@ -16,7 +16,7 @@ from corems.encapsulation.input.parameter_from_json import (
 from corems.mass_spectrum.calc.KendrickGroup import KendrickGrouping
 from corems.mass_spectrum.calc.MassSpectrumCalc import MassSpecCalc
 from corems.mass_spectrum.calc.MeanResolvingPowerFilter import MeanResolvingPowerFilter
-from corems.ms_peak.factory.MSPeakClasses import ICRMassPeak as MSPeak
+from corems.ms_peak.factory.MSPeakClasses import ICRMassPeak as MSPeak, PeakType
 
 __author__ = "Yuri E. Corilo"
 __date__ = "Jun 12, 2019"
@@ -216,6 +216,7 @@ class MassSpecBase(MassSpecCalc, KendrickGrouping):
             len(self._mspeaks),
             exp_freq=exp_freq,
             ms_parent=ms_parent,
+            peak_type=PeakType.REAL,
         )
 
         self._mspeaks.append(mspeak)

--- a/corems/ms_peak/factory/MSPeakClasses.py
+++ b/corems/ms_peak/factory/MSPeakClasses.py
@@ -2,12 +2,23 @@ __author__ = "Yuri E. Corilo"
 __date__ = "Jun 12, 2019"
 
 import math
+from enum import Enum, auto
 
 from numpy import nan
 
 from corems.mass_spectra.calc import SignalProcessing as sp
 from corems.molecular_formula.factory.MolecularFormulaFactory import MolecularFormula
 from corems.ms_peak.calc.MSPeakCalc import MSPeakCalculation
+
+
+class PeakType(Enum):
+    """Enumeration of MSPeak classification types."""
+
+    REAL = auto()
+    NOISE = auto()
+    SINC_WIGGLE = auto()
+    MAGNETRON = auto()
+    HARMONIC = auto()
 
 
 class _MSPeak(MSPeakCalculation):
@@ -69,6 +80,7 @@ class _MSPeak(MSPeakCalculation):
         index,
         ms_parent=None,
         exp_freq=None,
+        peak_type: PeakType = PeakType.REAL,
     ):
         self._ms_parent = ms_parent
         # needed to create the object
@@ -97,6 +109,8 @@ class _MSPeak(MSPeakCalculation):
         if exp_freq:
             self.freq_exp = float(exp_freq)
 
+        self._peak_type = peak_type
+
         if self._ms_parent is not None:
             kendrick_dict_base = self._ms_parent.mspeaks_settings.kendrick_base
         else:
@@ -115,7 +129,7 @@ class _MSPeak(MSPeakCalculation):
         self.found_isotopologues = {}
 
         # Label for what type of peak it is - real signal, noise, sinc wiggle, magnetron or harmonic peak, etc.
-        self.peak_type = None
+        # Stored in the _peak_type attribute
 
     def __len__(self):
         return len(self.molecular_formulas)
@@ -178,6 +192,15 @@ class _MSPeak(MSPeakCalculation):
     def clear_molecular_formulas(self):
         """Clears all molecular formulas associated with the peak."""
         self.molecular_formulas = []
+
+    @property
+    def peak_type(self) -> PeakType:
+        """Return the classification type of this peak."""
+        return self._peak_type
+
+    @peak_type.setter
+    def peak_type(self, value: PeakType):
+        self._peak_type = value
 
     @property
     def mz_exp(self):

--- a/tests/test_mspeak.py
+++ b/tests/test_mspeak.py
@@ -1,6 +1,6 @@
 import sys
 
-from corems.ms_peak.factory.MSPeakClasses import ICRMassPeak
+from corems.ms_peak.factory.MSPeakClasses import ICRMassPeak, PeakType
 
 
 def test_mspeaks_fit(mass_spectrum_ftms):
@@ -26,6 +26,7 @@ def test_mspeak_calculations():
         signal_to_noise,
         massspec_index,
         index,
+        peak_type=PeakType.REAL,
     )
     assert mspeak.resolving_power == 1000000
 


### PR DESCRIPTION
## Summary
- add `PeakType` enum
- accept `peak_type` in `_MSPeak` with property
- propagate default `PeakType.REAL` in `add_mspeak`
- update mspeak tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_6845f798693c8326b14eb88318fd2d15