### PR TITLE
Update docs with PeakType info

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ As an open source project, CoreMS welcomes contributions of all forms. Before co
 - Kendrick filter using density-based clustering
 - Kendrick classification
 - Heteroatoms classification and visualization
+- Peak classification using the `PeakType` enumeration and harmonic peak
+  detection with `detect_harmonic_peaks`
 
 ### GC-MS Signal Processing, Calibration, and Compound Identification
 

--- a/corems/encapsulation/constant.py
+++ b/corems/encapsulation/constant.py
@@ -2,9 +2,10 @@
 
 This module stores simple constant classes that are used across the
 project for labelling data, describing atoms and categorizing peaks.
-`PeakType` can be used when processing mass spectra to flag whether a
-peak is real or originates from artifacts such as harmonics or magnetron
-effects.
+
+``PeakType`` is an :class:`enum.Enum` used when processing mass spectra to
+flag whether a peak is a real signal or an artefact such as a harmonic or
+magnetron side band.
 """
 
 

--- a/corems/mass_spectrum/factory/MassSpectrumClasses.py
+++ b/corems/mass_spectrum/factory/MassSpectrumClasses.py
@@ -1442,7 +1442,9 @@ class MassSpecfromFreq(MassSpecBase):
         -----
         For every pair of peaks the ratio of their experimental frequencies is
         compared against the integers 2, 3 and 4. Peaks for which the ratio is
-        within ``tol`` of these integers are marked with ``PeakType.HARMONIC``.
+        within ``tol`` of these integers are flagged as harmonic by setting
+        their :pyattr:`~corems.ms_peak.factory.MSPeakClasses.MSPeak.peak_type`
+        to :class:`~corems.ms_peak.factory.MSPeakClasses.PeakType.HARMONIC`.
         When quadrupolar detection is enabled (``self.transient_settings.qpd_enabled``
         equals ``1``) only the less abundant peak of the pair is flagged as a
         harmonic.

--- a/corems/ms_peak/factory/MSPeakClasses.py
+++ b/corems/ms_peak/factory/MSPeakClasses.py
@@ -12,7 +12,21 @@ from corems.ms_peak.calc.MSPeakCalc import MSPeakCalculation
 
 
 class PeakType(Enum):
-    """Enumeration of MSPeak classification types."""
+    """Enumeration of peak classification types used by :class:`MSPeak`.
+
+    Members
+    -------
+    REAL
+        Genuine signal peak.
+    NOISE
+        Noise or background signal.
+    SINC_WIGGLE
+        Peaks originating from Fourier transform sinc wiggles.
+    MAGNETRON
+        Magnetron sidebands.
+    HARMONIC
+        Harmonic artifacts detected by :meth:`~corems.mass_spectrum.factory.MassSpecfromFreq.detect_harmonic_peaks`.
+    """
 
     REAL = auto()
     NOISE = auto()


### PR DESCRIPTION
## Summary
- document PeakType enum and harmonic detection features
- explain new enumeration in constants module
- note peak classification and harmonic peak detection in README

## Testing
- `make docu` *(fails: pdoc not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_684788df51548326840d43b40d3274f1